### PR TITLE
Add enhanced code highlighting with line numbers and copy functionality

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,14 @@ permalink   : /:year/:title/
 markdown    : kramdown
 highlighter : rouge
 
+# Kramdown settings
+kramdown:
+  syntax_highlighter: rouge
+  syntax_highlighter_opts:
+    block:
+      line_numbers: true
+      start_line: 1
+
 
 source      : ./
 destination : ./_site

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -20,3 +20,6 @@
 
   gtag('config', 'G-N8JW7K57P9');
 </script>
+
+<!-- Copy Code Functionality -->
+<script src="{{ '/assets/js/copy-code.js' | relative_url }}"></script>

--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -1,0 +1,165 @@
+/**
+ * Copy Code Functionality
+ * Adds copy buttons to code blocks for easy copying
+ */
+
+(function() {
+  'use strict';
+
+  /**
+   * Add copy buttons to all code blocks
+   */
+  function addCopyButtons() {
+    // Find all code blocks with the .highlight class
+    const codeBlocks = document.querySelectorAll('.highlight');
+
+    codeBlocks.forEach(function(codeBlock) {
+      // Skip if button already exists
+      if (codeBlock.querySelector('.copy-code-button')) {
+        return;
+      }
+
+      // Create the copy button
+      const button = document.createElement('button');
+      button.className = 'copy-code-button';
+      button.type = 'button';
+      button.textContent = 'Copy';
+      button.setAttribute('aria-label', 'Copy code to clipboard');
+
+      // Add click event listener
+      button.addEventListener('click', function() {
+        copyCode(codeBlock, button);
+      });
+
+      // Insert the button at the beginning of the code block
+      codeBlock.insertBefore(button, codeBlock.firstChild);
+    });
+  }
+
+  /**
+   * Copy code from a code block to clipboard
+   * @param {HTMLElement} codeBlock - The code block element
+   * @param {HTMLElement} button - The copy button element
+   */
+  function copyCode(codeBlock, button) {
+    let code;
+
+    // Check if code block has line numbers (table structure)
+    const codeElement = codeBlock.querySelector('.code pre');
+
+    if (codeElement) {
+      // Code block with line numbers - get text from .code column
+      code = codeElement.textContent;
+    } else {
+      // Code block without line numbers - get text from pre
+      const preElement = codeBlock.querySelector('pre');
+      code = preElement ? preElement.textContent : '';
+    }
+
+    // Remove any trailing whitespace
+    code = code.trim();
+
+    // Copy to clipboard using the Clipboard API
+    if (navigator.clipboard && window.isSecureContext) {
+      // Modern browsers with Clipboard API
+      navigator.clipboard.writeText(code).then(function() {
+        showCopySuccess(button);
+      }).catch(function(err) {
+        console.error('Failed to copy code: ', err);
+        fallbackCopyToClipboard(code, button);
+      });
+    } else {
+      // Fallback for older browsers
+      fallbackCopyToClipboard(code, button);
+    }
+  }
+
+  /**
+   * Fallback method to copy text to clipboard for older browsers
+   * @param {string} text - The text to copy
+   * @param {HTMLElement} button - The copy button element
+   */
+  function fallbackCopyToClipboard(text, button) {
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.style.position = 'fixed';
+    textArea.style.top = '0';
+    textArea.style.left = '0';
+    textArea.style.width = '2em';
+    textArea.style.height = '2em';
+    textArea.style.padding = '0';
+    textArea.style.border = 'none';
+    textArea.style.outline = 'none';
+    textArea.style.boxShadow = 'none';
+    textArea.style.background = 'transparent';
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    try {
+      const successful = document.execCommand('copy');
+      if (successful) {
+        showCopySuccess(button);
+      } else {
+        console.error('Fallback: Failed to copy code');
+      }
+    } catch (err) {
+      console.error('Fallback: Unable to copy', err);
+    }
+
+    document.body.removeChild(textArea);
+  }
+
+  /**
+   * Show success feedback on the copy button
+   * @param {HTMLElement} button - The copy button element
+   */
+  function showCopySuccess(button) {
+    const originalText = button.textContent;
+
+    button.textContent = 'Copied!';
+    button.classList.add('copied');
+
+    // Reset button after 2 seconds
+    setTimeout(function() {
+      button.textContent = originalText;
+      button.classList.remove('copied');
+    }, 2000);
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', addCopyButtons);
+  } else {
+    // DOM is already ready
+    addCopyButtons();
+  }
+
+  // Also reinitialize if new content is loaded dynamically
+  // (useful for single-page applications or dynamic content)
+  if (typeof MutationObserver !== 'undefined') {
+    const observer = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        if (mutation.addedNodes.length) {
+          addCopyButtons();
+        }
+      });
+    });
+
+    // Start observing when DOM is ready
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', function() {
+        observer.observe(document.body, {
+          childList: true,
+          subtree: true
+        });
+      });
+    } else {
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true
+      });
+    }
+  }
+})();

--- a/assets/scss/_syntax-highlighting.scss
+++ b/assets/scss/_syntax-highlighting.scss
@@ -2,6 +2,7 @@
 * Syntax highlighting styles
 */
 .highlight {
+  position: relative;
   margin: 1.5em 0;
   padding: 0;
   background-color: var(--code-bg);
@@ -15,14 +16,36 @@
     background-color: var(--code-bg);
     color: var(--code-color);
     overflow-x: auto;
-    
+
     code {
       padding: 0;
       background: none;
-      
+
       * {
         white-space: pre;
       }
+    }
+  }
+
+  // Table layout for line numbers
+  .highlight > pre {
+    padding: 0;
+  }
+
+  table {
+    margin: 0;
+    border-spacing: 0;
+    width: 100%;
+    border: none;
+
+    tbody {
+      display: table;
+      width: 100%;
+    }
+
+    td {
+      padding: 0;
+      border: none;
     }
   }
 
@@ -30,7 +53,72 @@
   .gutter {
     background-color: var(--code-bg);
     border-right: 1px solid var(--border-color);
-    opacity: 0.7;
+    padding: 1em 0.75em;
+    text-align: right;
+    user-select: none;
+    width: 1%;
+    min-width: 3em;
+
+    pre {
+      margin: 0;
+      padding: 0;
+      color: var(--code-color);
+      opacity: 0.5;
+    }
+
+    .lineno {
+      color: var(--code-color);
+      opacity: 0.5;
+      display: block;
+      line-height: 1.5;
+    }
+  }
+
+  // Code content column
+  .code {
+    padding: 1em;
+    width: 100%;
+
+    pre {
+      margin: 0;
+      padding: 0;
+    }
+  }
+
+  // Copy button styles
+  .copy-code-button {
+    position: absolute;
+    top: 0.5em;
+    right: 0.5em;
+    padding: 0.4em 0.8em;
+    font-size: 0.85em;
+    background-color: var(--inline-code-bg);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s ease, background-color 0.2s ease;
+    z-index: 10;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+
+    &:hover {
+      background-color: var(--border-color);
+    }
+
+    &:active {
+      transform: scale(0.95);
+    }
+
+    &.copied {
+      background-color: #28a745;
+      color: white;
+      border-color: #28a745;
+    }
+  }
+
+  &:hover .copy-code-button {
+    opacity: 1;
   }
 
   // Dark mode specific syntax colors


### PR DESCRIPTION
- Enable line numbers globally for all code blocks via Kramdown config
- Enhance syntax highlighting styles with improved line number formatting
- Add copy-to-clipboard functionality for code snippets with visual feedback
- Style copy button with hover effects and dark mode support
- Ensure proper table layout for line-numbered code blocks
- Add user-select: none to line numbers for better copy experience