### PR TITLE
Fix code block rendering issues with line numbers

### DIFF
--- a/assets/scss/_syntax-highlighting.scss
+++ b/assets/scss/_syntax-highlighting.scss
@@ -27,25 +27,31 @@
     }
   }
 
-  // Table layout for line numbers
-  .highlight > pre {
-    padding: 0;
-  }
-
+  // Table layout for line numbers - only remove padding when table exists
   table {
     margin: 0;
     border-spacing: 0;
     width: 100%;
     border: none;
+    display: table;
 
     tbody {
-      display: table;
-      width: 100%;
+      display: table-row-group;
+    }
+
+    tr {
+      display: table-row;
     }
 
     td {
       padding: 0;
       border: none;
+      display: table-cell;
+    }
+
+    pre {
+      padding: 0;
+      overflow-x: auto;
     }
   }
 
@@ -58,19 +64,20 @@
     user-select: none;
     width: 1%;
     min-width: 3em;
+    vertical-align: top;
 
     pre {
       margin: 0;
       padding: 0;
       color: var(--code-color);
       opacity: 0.5;
+      overflow-x: visible;
     }
 
     .lineno {
       color: var(--code-color);
       opacity: 0.5;
       display: block;
-      line-height: 1.5;
     }
   }
 
@@ -78,6 +85,7 @@
   .code {
     padding: 1em;
     width: 100%;
+    vertical-align: top;
 
     pre {
       margin: 0;


### PR DESCRIPTION
- Remove problematic CSS rule that stripped padding from all pre elements
- Only apply zero padding when table structure exists (line numbers present)
- Add proper table display properties for correct rendering
- Add vertical-align: top to gutter and code cells for proper alignment
- Prevent overflow issues on line number column
- Remove conflicting line-height from line numbers

This fixes the broken code block display while maintaining line numbers and copy functionality.